### PR TITLE
link.ld: enlarge text section size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: make -j 2
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MLOAD
         if-no-files-found: error

--- a/link.ld
+++ b/link.ld
@@ -5,13 +5,13 @@ ENTRY(_start)
 /* Sections area */
 MEMORY {
 	table		: ORIGIN = 0x0, LENGTH = 0x4000
-	exe(rwx)	: ORIGIN = 0x136d0000, LENGTH = 0x2000
-	ram(rw)		: ORIGIN = 0x136d2000, LENGTH = 0x9000
+	exe(rwx)	: ORIGIN = 0x136d0000, LENGTH = 0x2400
+	ram(rw)		: ORIGIN = 0x136d2400, LENGTH = 0x9000
 	mem(rw)		: ORIGIN = 0x13700000, LENGTH = 0x80000
 }
 
 __exe_start_phys__		= 0x136d0000;
-__ram_start_phys__		= 0x136d2000;
+__ram_start_phys__		= 0x136d2400;
 __mem_start_phys__		= 0x13700000;
 
 


### PR DESCRIPTION
The size 0x2000 is not enough when NO_DEBUG_BUFFER is not used.

Fixes: https://github.com/xerpi/mload-mod/issues/1

(I've yet to test it on an actual Wii)